### PR TITLE
Update fixes

### DIFF
--- a/Project Files/TableSchemerTests/TableScheme_Tests.swift
+++ b/Project Files/TableSchemerTests/TableScheme_Tests.swift
@@ -148,7 +148,7 @@ class TableScheme_Tests: XCTestCase {
         let tableView = configuredTableView()
         subject.hideScheme(schemeSet4Scheme1, inTableView: tableView)
         subject.hideScheme(schemeSet4Scheme2, inTableView: tableView)
-        let cell = subject.tableView(tableView, cellForRowAtIndexPath: NSIndexPath(forRow: 1, inSection: 2))
+        let cell = subject.tableView(tableView, cellForRowAtIndexPath: NSIndexPath(forRow: 1, inSection: 3))
         let configureCall = schemeSet4Scheme3.lastConfigureCall
         XCTAssert(configureCall.cell === cell)
         XCTAssert(configureCall.relativeIndex == 1)

--- a/Project Files/TableSchemerTests/TableScheme_Tests.swift
+++ b/Project Files/TableSchemerTests/TableScheme_Tests.swift
@@ -143,6 +143,16 @@ class TableScheme_Tests: XCTestCase {
         XCTAssert(configureCall.cell === cell)
         XCTAssert(configureCall.relativeIndex == 1)
     }
+
+    func testCellForRowAtIndexPath_accountsForMultipleHiddenSchemes() {
+        let tableView = configuredTableView()
+        subject.hideScheme(schemeSet4Scheme1, inTableView: tableView)
+        subject.hideScheme(schemeSet4Scheme2, inTableView: tableView)
+        let cell = subject.tableView(tableView, cellForRowAtIndexPath: NSIndexPath(forRow: 1, inSection: 2))
+        let configureCall = schemeSet4Scheme3.lastConfigureCall
+        XCTAssert(configureCall.cell === cell)
+        XCTAssert(configureCall.relativeIndex == 1)
+    }
     
     // MARK: Title For Header In Section
     func testTitleForHeaderInSection_whenProvided_isCorrect() {

--- a/Sources/TableScheme.swift
+++ b/Sources/TableScheme.swift
@@ -133,15 +133,11 @@ public class TableScheme: NSObject, UITableViewDataSource {
         var priorHiddenSchemes = 0
         
         for (idx, scheme) in enumerate(schemeSet.schemes) {
-            if (idx + offset > row) {
-                break
-            }
-            
             if scheme.hidden {
                 priorHiddenSchemes++
                 continue
             }
-            
+
             if row >= (idx + offset - priorHiddenSchemes) && row < (idx + offset + scheme.numberOfCells - priorHiddenSchemes) {
                 return scheme
             } else {
@@ -149,7 +145,7 @@ public class TableScheme: NSObject, UITableViewDataSource {
             }
         }
         
-        return schemeSet[row - offset + priorHiddenSchemes]
+        return nil
     }
     
     /**

--- a/Sources/TableSchemeBatchAnimator.swift
+++ b/Sources/TableSchemeBatchAnimator.swift
@@ -113,10 +113,15 @@ public final class TableSchemeBatchAnimator {
     
     // MARK: - Internal methods
     func performVisibilityChanges() {
+        // Don't notify table view of changes in hidden scheme sets, or scheme sets we're already notifying about.
+        let ignoredSchemeSets = tableScheme.schemeSets.filter { $0.hidden } + (sectionDeletions + sectionInsertions + sectionReloads).map { $0.schemeSet }
+
         // Get the index paths of the schemes we are deleting. This will give us the deletion index paths. We need to do
         // this before marking them as hidden so indexPathForScheme doesn't skip it
-        
-        let deleteRows = rowDeletions.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
+
+        let deleteRows = rowDeletions.filter {
+            find(ignoredSchemeSets, self.tableScheme.schemeSetWithScheme($0.scheme)) == nil
+        }.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
             if memo[change.animation] == nil {
                 memo[change.animation] = [NSIndexPath]()
             }
@@ -138,7 +143,9 @@ public final class TableSchemeBatchAnimator {
         
         // We also need the index paths of the reloaded schemes and sections before making changes to the table.
         
-        let reloadRows = rowReloads.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
+        let reloadRows = rowReloads.filter {
+            find(ignoredSchemeSets, self.tableScheme.schemeSetWithScheme($0.scheme)) == nil
+        }.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
             if memo[change.animation] == nil {
                 memo[change.animation] = [NSIndexPath]()
             }
@@ -179,7 +186,9 @@ public final class TableSchemeBatchAnimator {
         // Now obtain the index paths for the inserted schemes. These will have their inserted index paths, skipping ones removed,
         // and correctly finding the ones that are visible
         
-        let insertRows = rowInsertions.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
+        let insertRows = rowInsertions.filter {
+            find(ignoredSchemeSets, self.tableScheme.schemeSetWithScheme($0.scheme)) == nil
+        }.reduce([UITableViewRowAnimation: [NSIndexPath]]()) { (var memo, change) in
             if memo[change.animation] == nil {
                 memo[change.animation] = [NSIndexPath]()
             }


### PR DESCRIPTION
Fixes a couple of issues I ran into with reordering. The first was it would return a hidden scheme if you had consecutive hidden schemes.

the second is when you want to hide a row in a section which is (initially) hidden - it won't have an initial indexPath so it shouldn't be added to the tableView's changes.