### PR TITLE
Adds support for custom state changes to `RadioScheme`

### DIFF
--- a/TableSchemer/RadioScheme.swift
+++ b/TableSchemer/RadioScheme.swift
@@ -24,7 +24,7 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
     
     public typealias ConfigurationHandler = (_ cell: CellType, _ index: Int) -> Void
     public typealias SelectionHandler = (_ cell: CellType, _ scheme: RadioScheme, _ index: Int) -> Void
-    public typealias AppearanceHandler = (_ cell: CellType, _ scheme: RadioScheme, _ index: Int, _ selected: Bool) -> Void
+    public typealias StateHandler = (_ cell: CellType, _ scheme: RadioScheme, _ index: Int, _ selected: Bool) -> Void
     
     /** The currently selected index. */
     open var selectedIndex = 0
@@ -47,14 +47,14 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
     open var selectionHandler: SelectionHandler?
 
     /**
-     The closure called when a cells selection appearance should be updated. By
+     The closure called when a cells selection state should be updated. By
      default, this will update the accessory type to `.checkmark` for the selected
-     cell, and `.none` for the deselected cell.
+     cell, and `.none` for a deselected cell.
 
      Do not use this closure as a way to handle selection; assign a selectionHandler
      instead as this closure is called during configuration as well.
      */
-    open var appearanceHandler: AppearanceHandler = { cell, _, _, selected in
+    open var stateHandler: StateHandler = { cell, _, _, selected in
         cell.accessoryType = selected ? .checkmark : .none
     }
 
@@ -72,7 +72,7 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
     
     open func configureCell(_ cell: UITableViewCell, withRelativeIndex relativeIndex: Int)  {
         configurationHandler(cell as! CellType, relativeIndex)
-        appearanceHandler(cell as! CellType, self, relativeIndex, selectedIndex == relativeIndex)
+        stateHandler(cell as! CellType, self, relativeIndex, selectedIndex == relativeIndex)
     }
     
     open func selectCell(_ cell: UITableViewCell, inTableView tableView: UITableView, inSection section: Int, havingRowsBeforeScheme rowsBeforeScheme: Int, withRelativeIndex relativeIndex: Int) {
@@ -89,10 +89,10 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
         selectedIndex = relativeIndex
         
         if let previouslySelectedCell = tableView.cellForRow(at: IndexPath(row: rowsBeforeScheme + oldSelectedIndex, section: section)) {
-            appearanceHandler(previouslySelectedCell as! CellType, self, oldSelectedIndex, false)
+            stateHandler(previouslySelectedCell as! CellType, self, oldSelectedIndex, false)
         }
 
-        appearanceHandler(cell as! CellType, self, relativeIndex, true)
+        stateHandler(cell as! CellType, self, relativeIndex, true)
     }
     
     open func reuseIdentifier(forRelativeIndex relativeIndex: Int) -> String {

--- a/TableSchemer/RadioScheme.swift
+++ b/TableSchemer/RadioScheme.swift
@@ -24,6 +24,7 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
     
     public typealias ConfigurationHandler = (_ cell: CellType, _ index: Int) -> Void
     public typealias SelectionHandler = (_ cell: CellType, _ scheme: RadioScheme, _ index: Int) -> Void
+    public typealias AppearanceHandler = (_ cell: CellType, _ scheme: RadioScheme, _ index: Int, _ selected: Bool) -> Void
     
     /** The currently selected index. */
     open var selectedIndex = 0
@@ -45,6 +46,18 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
      */
     open var selectionHandler: SelectionHandler?
 
+    /**
+     The closure called when a cells selection appearance should be updated. By
+     default, this will update the accessory type to `.checkmark` for the selected
+     cell, and `.none` for the deselected cell.
+
+     Do not use this closure as a way to handle selection; assign a selectionHandler
+     instead as this closure is called during configuration as well.
+     */
+    open var appearanceHandler: AppearanceHandler = { cell, _, _, selected in
+        cell.accessoryType = selected ? .checkmark : .none
+    }
+
     public init(expandedCellTypes: [UITableViewCell.Type], configurationHandler: @escaping ConfigurationHandler) {
         self.expandedCellTypes = expandedCellTypes
         self.configurationHandler = configurationHandler
@@ -59,12 +72,7 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
     
     open func configureCell(_ cell: UITableViewCell, withRelativeIndex relativeIndex: Int)  {
         configurationHandler(cell as! CellType, relativeIndex)
-        
-        if selectedIndex == relativeIndex {
-            cell.accessoryType = .checkmark
-        } else {
-            cell.accessoryType = .none
-        }
+        appearanceHandler(cell as! CellType, self, relativeIndex, selectedIndex == relativeIndex)
     }
     
     open func selectCell(_ cell: UITableViewCell, inTableView tableView: UITableView, inSection section: Int, havingRowsBeforeScheme rowsBeforeScheme: Int, withRelativeIndex relativeIndex: Int) {
@@ -81,10 +89,10 @@ open class RadioScheme<CellType: UITableViewCell>: Scheme {
         selectedIndex = relativeIndex
         
         if let previouslySelectedCell = tableView.cellForRow(at: IndexPath(row: rowsBeforeScheme + oldSelectedIndex, section: section)) {
-            previouslySelectedCell.accessoryType = .none
+            appearanceHandler(previouslySelectedCell as! CellType, self, oldSelectedIndex, false)
         }
-        
-        cell.accessoryType = .checkmark
+
+        appearanceHandler(cell as! CellType, self, relativeIndex, true)
     }
     
     open func reuseIdentifier(forRelativeIndex relativeIndex: Int) -> String {

--- a/TableSchemer/RadioSchemeBuilder.swift
+++ b/TableSchemer/RadioSchemeBuilder.swift
@@ -14,7 +14,7 @@ open class RadioSchemeBuilder<CellType: UITableViewCell>: SchemeBuilder {
 
     open var configurationHandler: SchemeType.ConfigurationHandler?
     open var selectionHandler: SchemeType.SelectionHandler?
-    open var appearanceHandler: SchemeType.AppearanceHandler?
+    open var stateHandler: SchemeType.StateHandler?
     open var expandedCellTypes: [UITableViewCell.Type]?
     open var selectedIndex = 0
     open var heights: [RowHeight]?
@@ -33,8 +33,8 @@ open class RadioSchemeBuilder<CellType: UITableViewCell>: SchemeBuilder {
         scheme.selectedIndex = selectedIndex
         scheme.selectionHandler = selectionHandler
 
-        if let appearanceHandler = appearanceHandler {
-            scheme.appearanceHandler = appearanceHandler
+        if let stateHandler = stateHandler {
+            scheme.stateHandler = stateHandler
         }
 
         return scheme

--- a/TableSchemer/RadioSchemeBuilder.swift
+++ b/TableSchemer/RadioSchemeBuilder.swift
@@ -14,6 +14,7 @@ open class RadioSchemeBuilder<CellType: UITableViewCell>: SchemeBuilder {
 
     open var configurationHandler: SchemeType.ConfigurationHandler?
     open var selectionHandler: SchemeType.SelectionHandler?
+    open var appearanceHandler: SchemeType.AppearanceHandler?
     open var expandedCellTypes: [UITableViewCell.Type]?
     open var selectedIndex = 0
     open var heights: [RowHeight]?
@@ -31,6 +32,11 @@ open class RadioSchemeBuilder<CellType: UITableViewCell>: SchemeBuilder {
         scheme.heights = heights
         scheme.selectedIndex = selectedIndex
         scheme.selectionHandler = selectionHandler
+
+        if let appearanceHandler = appearanceHandler {
+            scheme.appearanceHandler = appearanceHandler
+        }
+
         return scheme
     }
     

--- a/TableSchemerExamples/MasterViewController.swift
+++ b/TableSchemerExamples/MasterViewController.swift
@@ -130,7 +130,39 @@ class MasterViewController: UITableViewController {
                 }
             }
 
+            builder.buildSchemeSet { builder in
+                builder.headerText = "Custom Appearance Radio Sample"
+
+                builder.buildScheme { (scheme: RadioSchemeBuilder) in
+                    scheme.expandedCellTypes = [ColorizedTableViewCell.Type](repeating: ColorizedTableViewCell.self, count: 5)
+
+                    scheme.configurationHandler = { cell, index in
+                        cell.textLabel?.text = "Radio Button \(index + 1)"
+                    }
+
+                    scheme.selectionHandler = { [unowned self] cell, scheme, index in
+                        print("You selected \(index)!")
+                        self.radioSelection = index
+                    }
+
+                    scheme.appearanceHandler = { cell, _, _, selected in
+                        cell.backgroundColor = selected ? .green : .red
+                    }
+                }
+            }
+
         }
     }
 }
 
+fileprivate class ColorizedTableViewCell: UITableViewCell {
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.backgroundColor = .clear
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        textLabel?.backgroundColor = .clear
+    }
+}

--- a/TableSchemerExamples/MasterViewController.swift
+++ b/TableSchemerExamples/MasterViewController.swift
@@ -145,7 +145,7 @@ class MasterViewController: UITableViewController {
                         self.radioSelection = index
                     }
 
-                    scheme.appearanceHandler = { cell, _, _, selected in
+                    scheme.stateHandler = { cell, _, _, selected in
                         cell.backgroundColor = selected ? .green : .red
                     }
                 }

--- a/TableSchemerTests/RadioScheme_Tests.swift
+++ b/TableSchemerTests/RadioScheme_Tests.swift
@@ -57,6 +57,38 @@ class RadioScheme_Tests: XCTestCase {
         
         XCTAssertEqual(cell.accessoryType, UITableViewCell.AccessoryType.none)
     }
+
+    func testConfigureCell_whenSelected_withCustomAppearanceHandler_usesCustomAppearanceHandler() {
+        configureSubjectWithConfigurationHandler()
+        subject.selectedIndex = 1
+
+        let testColor = UIColor.red
+        subject.appearanceHandler = { cell, _, _, selected in
+            XCTAssertTrue(selected)
+            cell.backgroundColor = testColor
+        }
+
+        let cell = UITableViewCell()
+        subject.configureCell(cell, withRelativeIndex: 1)
+
+        XCTAssertEqual(testColor, cell.backgroundColor)
+    }
+
+    func testConfigureCell_whenNotSelected_withCustomAppearanceHandler_usesCustomAppearanceHandler() {
+        configureSubjectWithConfigurationHandler()
+        subject.selectedIndex = 1
+
+        let testColor = UIColor.red
+        subject.appearanceHandler = { cell, _, _, selected in
+            XCTAssertFalse(selected)
+            cell.backgroundColor = testColor
+        }
+
+        let cell = UITableViewCell()
+        subject.configureCell(cell, withRelativeIndex: 0)
+
+        XCTAssertEqual(testColor, cell.backgroundColor)
+    }
     
     // MARK: Selecing Cell
     func testSelectCell_updatesSelectedIndex() {

--- a/TableSchemerTests/RadioScheme_Tests.swift
+++ b/TableSchemerTests/RadioScheme_Tests.swift
@@ -58,12 +58,12 @@ class RadioScheme_Tests: XCTestCase {
         XCTAssertEqual(cell.accessoryType, UITableViewCell.AccessoryType.none)
     }
 
-    func testConfigureCell_whenSelected_withCustomAppearanceHandler_usesCustomAppearanceHandler() {
+    func testConfigureCell_whenSelected_withCustomStateHandler_usesCustomStateHandler() {
         configureSubjectWithConfigurationHandler()
         subject.selectedIndex = 1
 
         let testColor = UIColor.red
-        subject.appearanceHandler = { cell, _, _, selected in
+        subject.stateHandler = { cell, _, _, selected in
             XCTAssertTrue(selected)
             cell.backgroundColor = testColor
         }
@@ -74,12 +74,12 @@ class RadioScheme_Tests: XCTestCase {
         XCTAssertEqual(testColor, cell.backgroundColor)
     }
 
-    func testConfigureCell_whenNotSelected_withCustomAppearanceHandler_usesCustomAppearanceHandler() {
+    func testConfigureCell_whenNotSelected_withCustomStateHandler_usesCustomStateHandler() {
         configureSubjectWithConfigurationHandler()
         subject.selectedIndex = 1
 
         let testColor = UIColor.red
-        subject.appearanceHandler = { cell, _, _, selected in
+        subject.stateHandler = { cell, _, _, selected in
             XCTAssertFalse(selected)
             cell.backgroundColor = testColor
         }


### PR DESCRIPTION
This enhances `RadioScheme` to allow you to specify the state changes done to a cell within a `RadioScheme`. The default will be the current behavior of setting the `accessoryType` to a checkmark when selected and none when unselected.
