### PR TITLE
adds scrollViewDidEndDecelerating handler

### DIFF
--- a/TableSchemer/TableScheme.swift
+++ b/TableSchemer/TableScheme.swift
@@ -25,6 +25,11 @@ public class TableScheme: NSObject {
     */
     public var scrollViewDidScrollHandler: ((_ scrollView: UIScrollView) -> Void)?
     
+    /**
+     A block that gets forwarded from the `scrollViewDidEndDecelerating(_:)` delegate method. Make sure to avoid retain cycles by specifing `[weak self]` if necessary.
+    */
+    public var scrollViewDidEndDeceleratingHandler: ((_ scrollView: UIScrollView) -> Void)?
+    
     #if DEBUG
     private var buildingBatchAnimations = false
     #endif
@@ -636,6 +641,10 @@ extension TableScheme: UITableViewDelegate {
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         scrollViewDidScrollHandler?(scrollView)
+    }
+    
+    public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        scrollViewDidEndDeceleratingHandler?(scrollView)
     }
     
 }

--- a/TableSchemerTests/TableScheme_Tests.swift
+++ b/TableSchemerTests/TableScheme_Tests.swift
@@ -964,13 +964,24 @@ class TableScheme_Tests: XCTestCase {
     // MARK: Handlers
     
     func testScrollViewDidScrollHandler() {
-        let expectation = self.expectation(description: "scroll view handler called")
+        let expectation = self.expectation(description: "scroll view did scroll handler called")
         subject.scrollViewDidScrollHandler = { scrollView in
             XCTAssert(scrollView === self.tableView)
             expectation.fulfill()
         }
         
         subject.scrollViewDidScroll(tableView)
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+    
+    func testScrollViewDidEndDeceleratingHandler() {
+        let expectation = self.expectation(description: "scroll view did end decelerating handler called")
+        subject.scrollViewDidEndDeceleratingHandler = { scrollView in
+            XCTAssert(scrollView === self.tableView)
+            expectation.fulfill()
+        }
+        
+        subject.scrollViewDidEndDecelerating(tableView)
         waitForExpectations(timeout: 1.0, handler: nil)
     }
     


### PR DESCRIPTION
This allows the `TableScheme` to pass its `scrollViewDidEndDecelerating` event through to an optional handler. 